### PR TITLE
Fix readme typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ Notice the values produced by `my_string` generator. They grow in *size* and *co
 `scalar` generators are interesting but can only take you so far. We now will explore the ideas around composition. Lets build on the previous generators.
 
 ```ruby
-my_hash = gen.hash(:fixnum => my_fixnum, :string => my_strings)
+my_hash = gen.hash(:fixnum => my_fixnum, :string => my_string)
 my_hash.sample => [{:fixnum=>0, :string=>""},
                    {:fixnum=>1, :string=>"9"},
                    {:fixnum=>-1, :string=>"1"},


### PR DESCRIPTION
I spotted this when working through the examples in the readme. The rest executed with no issues.

Side note: thanks for publishing this project! I was considering porting test.check to Ruby but fortunately stumbled across this before I got too far. I look forward to playing around with this some more in the near future.